### PR TITLE
Redirect to tree at start.

### DIFF
--- a/rando.py
+++ b/rando.py
@@ -49,7 +49,7 @@ class RandomHandler(RequestHandler):
         loop = ioloop.IOLoop.current()
         yield gen.Task(loop.add_timeout, loop.time() + 1.1)
 
-        self.redirect("/" + random_path, permanent=False)
+        self.redirect("/" + random_path + "/tree", permanent=False)
 
     @gen.coroutine
     def wait_for_server(self, ip, port, timeout=10, wait_time=0.2):


### PR DESCRIPTION
Shave off a whopping ~74ms from page load by having the first redirect just take you to `/tree` instead of having the notebook server redirect you there.
