### PR TITLE
allow requesting specific user IDs

### DIFF
--- a/rando.py
+++ b/rando.py
@@ -77,7 +77,7 @@ def cull_idle(docker_client, proxy_token, delta=None):
 
 class LoadingHandler(RequestHandler):
     def get(self, path=None):
-        self.render("loading.html")
+        self.render("loading.html", path=path)
 
 class SpawnHandler(RequestHandler):
 

--- a/templates/loading.html
+++ b/templates/loading.html
@@ -9,9 +9,12 @@
 
   <div class="jumbotron">
     <div class="container text-center">
-    <h1>Jupyter Demo</h1>
-    <p>Starting a new notebook server, just for you...<p>
-      </div>
+      <h1>Jupyter Demo</h1>
+      {% if path %}
+      <p>The server you requested is no longer running or it doesn't exist.</p>
+      {% end %}
+      <p>Starting a new notebook server, just for you...<p>
+    </div>
   </div>
 
   <script type="text/javascript">


### PR DESCRIPTION
Visiting /user-foo/ will no longer 404 if it went down. Instead, it will start up a new server at that URL.
