### PR TITLE
Enforce local installation

### DIFF
--- a/launchie.sh
+++ b/launchie.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 export CONFIGPROXY_AUTH_TOKEN=`head -c 30 /dev/urandom | xxd -p`
-configurable-http-proxy --default-target=http://localhost:9999 &
+node_modules/.bin/configurable-http-proxy --default-target=http://localhost:9999 &
 python rando.py $@
 kill %%


### PR DESCRIPTION
Since launchie.sh is being used for dev, might as well point at the local node_modules.
