### PR TITLE
Check the status of the notebook itself

### DIFF
--- a/rando.py
+++ b/rando.py
@@ -96,9 +96,6 @@ class RandomHandler(RequestHandler):
         # Wait for the notebook server to come up.
         yield self.wait_for_server("127.0.0.1", port, random_path)
 
-        #loop = ioloop.IOLoop.current()
-        #yield gen.Task(loop.add_timeout, loop.time() + 1.1)
-
         self.redirect("/" + random_path + "/tree", permanent=False)
 
     @gen.coroutine


### PR DESCRIPTION
Turns out the port is up (nearly) instantaneously, but we still have to wait for the Notebook server to boot up. This rolls through until an HTTP Error isn't seen anymore.

Side questions: Are there ways to optimize starting a notebook server? This one does launch straight from `master`.
