### PR TITLE
Switch to 127.0.0.1

### DIFF
--- a/dockworker.py
+++ b/dockworker.py
@@ -18,7 +18,7 @@ def cull_idle(docker_client, proxy_token, delta=None):
     dt = datetime.datetime.utcnow() - delta
     timestamp = dt.isoformat() + 'Z'
 
-    routes_url = "http://localhost:8001/api/routes"
+    routes_url = "http://127.0.0.1:8001/api/routes"
 
     url = url_concat(routes_url,
                      {'inactive_since': timestamp})

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -205,7 +205,7 @@ class SpawnHandler(RequestHandler):
 
         proxy_endpoint = self.proxy_endpoint + "/api/routes/{}".format(base_path)
         body = json.dumps({
-            "target": "http://localhost:{}".format(port),
+            "target": "http://127.0.0.1:{}".format(port),
             "container_id": container_id,
         })
 
@@ -251,7 +251,7 @@ def main():
     ]
 
     proxy_token = os.environ['CONFIGPROXY_AUTH_TOKEN']
-    proxy_endpoint = os.environ.get('CONFIGPROXY_ENDPOINT', "http://localhost:8001")
+    proxy_endpoint = os.environ.get('CONFIGPROXY_ENDPOINT', "http://127.0.0.1:8001")
     docker_host = os.environ.get('DOCKER_HOST', 'unix://var/run/docker.sock')
     
     blocking_docker_client = docker.Client(base_url=docker_host, timeout=10)

--- a/script/dev
+++ b/script/dev
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 export CONFIGPROXY_AUTH_TOKEN=`head -c 30 /dev/urandom | xxd -p`
-node_modules/.bin/configurable-http-proxy --default-target=http://localhost:9999 &
+node_modules/.bin/configurable-http-proxy --default-target=http://127.0.0.1:9999 &
 python orchestrate.py $@
 kill %%


### PR DESCRIPTION
Like it says on the tin.

`s/localhost/127.0.0.1/`

We were getting network issues with resolving `localhost` after running the config proxy for a while. This was also addressed in #47, but that one needs more fixes to be merged.
