### PR TITLE
Make endpoint configurable for culler too

### DIFF
--- a/dockworker.py
+++ b/dockworker.py
@@ -10,7 +10,7 @@ from tornado.httpclient import HTTPRequest, HTTPError, AsyncHTTPClient
 AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
 
 @gen.coroutine
-def cull_idle(docker_client, proxy_token, delta=None):
+def cull_idle(docker_client, proxy_endpoint, proxy_token, delta=None):
     if delta is None:
         delta = datetime.timedelta(minutes=60)
     http_client = AsyncHTTPClient()
@@ -18,7 +18,7 @@ def cull_idle(docker_client, proxy_token, delta=None):
     dt = datetime.datetime.utcnow() - delta
     timestamp = dt.isoformat() + 'Z'
 
-    routes_url = "http://127.0.0.1:8001/api/routes"
+    routes_url = proxy_endpoint + "/api/routes"
 
     url = url_concat(routes_url,
                      {'inactive_since': timestamp})

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -321,7 +321,7 @@ def main():
         cull_ms = cull_timeout * 1e3
         app_log.info("Culling every %i seconds", cull_timeout)
         culler = tornado.ioloop.PeriodicCallback(
-            lambda : cull_idle(async_docker_client, proxy_token, delta),
+            lambda : cull_idle(async_docker_client, proxy_endpoint, proxy_token, delta),
             cull_ms
         )
         culler.start()


### PR DESCRIPTION
The culler should allow for a configurable configurable (sic) proxy endpoint.
