### PR TITLE
Allow for example.org/user-blah

### DIFF
--- a/orchestrate.py
+++ b/orchestrate.py
@@ -219,8 +219,8 @@ def main():
 
     handlers = [
         (r"/", LoadingHandler),
-        (r"/spawn/?(/user-\w+/.+)?", SpawnHandler),
-        (r"/(user-\w+)/.*", LoadingHandler),
+        (r"/spawn/?(/user-\w+(?:/.*)?)?", SpawnHandler),
+        (r"/(user-\w+)(?:/.*)?", LoadingHandler),
     ]
 
     proxy_token = os.environ['CONFIGPROXY_AUTH_TOKEN']


### PR DESCRIPTION
Adds ability to handle paths like

```
example.org/user-somemadeupname
```
