### PR TITLE
Enable gists for the demo image.

### DIFF
--- a/images/demo/Dockerfile
+++ b/images/demo/Dockerfile
@@ -39,6 +39,8 @@ USER root
 ADD Julia/ /srv/Julia/
 ADD R/ /srv/R/
 ADD notebooks/ /home/jupyter/
+ADD https://rawgithub.com/minrk/ipython_extensions/master/nbextensions/gist.js /home/jupyter/.ipython/nbextensions/gist.js
+ADD custom.js /home/jupyter/.ipython/profile_default/static/custom/custom.js
 
 # Add Google Analytics templates
 ADD ga/ /srv/ga/

--- a/images/demo/custom.js
+++ b/images/demo/custom.js
@@ -1,0 +1,1 @@
+IPython.load_extensions('gist');


### PR DESCRIPTION
This uses @minrk's notebook extension for sharing as gist.

![screen shot 2014-10-14 at 4 33 20 pm](https://cloud.githubusercontent.com/assets/836375/4638440/88015754-53fa-11e4-80f9-dc8204c9f00e.png)

We should probably discuss this one before merge, since:
- We're `ADD`ing a remote resource (it's Min's, but still)
- Users should be given a warning about providing a token on a hosted tmpnb server
- Liabilities?
