### PR TITLE
Stats endpoint

### DIFF
--- a/orchestrate.py
+++ b/orchestrate.py
@@ -31,6 +31,7 @@ class StatsHandler(RequestHandler):
         response = {
                 'available': len(self.pool.available),
                 'capacity': self.pool.capacity,
+                'version': '0.0.1',
         }
         self.write(response)
 


### PR DESCRIPTION
Create a basic stats endpoint so that external routing can decide where to route users and we can see how full a given server is.
