### PR TITLE
Use wss by default

### DIFF
--- a/templates/loading.html
+++ b/templates/loading.html
@@ -24,7 +24,7 @@
 
         <div id="websockets-uhoh">
           <p>Uh oh. Either your network does not allow WebSockets (needed to communicate with IPython) or your browser is unsupported. Please use:</p>
-            <ul>
+            <ul style="list-style: none;">
               <li>Chrome ≥ 13</li>
               <li>Safari ≥ 5</li>
               <li>Firefox ≥ 6</li>


### PR DESCRIPTION
This should have been wss by default, otherwise Chrome will block `ws:`. Perhaps the echo service should be run by tmpnb itself instead.
