### PR TITLE
Explicitly disallow /user/ and /spawn/, allow others

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
-Disallow: /
+Disallow: /user/
+Disallow: /spawn/


### PR DESCRIPTION
Now that users are on their own pseudo-directory path, we can open the front page and other endpoints up to being traversable.