### PR TITLE
handle invalid container data

### DIFF
--- a/dockworker.py
+++ b/dockworker.py
@@ -136,7 +136,12 @@ class DockerSpawner():
                                             trunc=False)
 
         def name_matches(container):
-            for name in container['Names']:
+            try:
+                names = container['Names']
+            except Exception:
+                app_log.warn("Invalid container: %r", container)
+                return False
+            for name in names:
                 if pool_regex.search(name):
                     return True
             return False


### PR DESCRIPTION
Under some circumstances, a container can be None

I'm not sure what causes the value to be None, but I assume it is a docker-py bug.

This brought down tmpnb yesterday. I haven't been able to figure out what caused it to return None in the first place, and I don't actually know if this will be enough to recover from the root problem, but it should at least avoid the specific error that killed tmpnb.