### PR TITLE
update pip to avoid importerror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:14.04
 
 RUN apt-get update && apt-get upgrade -y && apt-get install python-pip python python-dev libcurl4-openssl-dev -y
+RUN easy_install -U pip
 RUN pip install tornado docker-py pycurl futures
 
 ADD . /srv/tmpnb/


### PR DESCRIPTION
Hi, 
when I execute tmpnb I get the following error during the construction of the Dockerimage.
Apparently this is [well known error](https://stackoverflow.com/questions/27341064/how-do-i-fix-importerror-cannot-import-name-incompleteread) and is due to the outdated pip version shipped in Ubuntu 14.04.
Updating pip fixes this problem.
Feel free to reject this PR if you have a more elegant solution.

``` 
---> Running in 69e4887cdb36
Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    load_entry_point('pip==1.5.4', 'console_scripts', 'pip')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 351, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2363, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2088, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/usr/lib/python2.7/dist-packages/pip/__init__.py", line 11, in <module>
    from pip.vcs import git, mercurial, subversion, bazaar  # noqa
  File "/usr/lib/python2.7/dist-packages/pip/vcs/mercurial.py", line 9, in <module>
    from pip.download import path_to_url
  File "/usr/lib/python2.7/dist-packages/pip/download.py", line 25, in <module>
    from requests.compat import IncompleteRead
ImportError: cannot import name IncompleteRead
INFO[0303] The command [/bin/sh -c pip install -r requirements.txt] returned a non-zero code: 1 
Makefile:8: recipe for target 'tmpnb-image' failed
```