### PR TITLE
[WIP] Accept the DOCKER_CERT_PATH

### DIFF
--- a/orchestrate.py
+++ b/orchestrate.py
@@ -187,6 +187,7 @@ def main():
                                        version=opts.docker_version,
                                        timeout=30,
                                        max_workers=opts.max_dock_workers,
+                                       docker_cert_path=os.environ.get('DOCKER_CERT_PATH')
     )
 
     static_path = os.path.join(os.path.dirname(__file__), "static")


### PR DESCRIPTION
Going after #136. The biggest piece is TLS.

The way we've been handling everything is with a mounted Docker socket. On the swarm environment I'm tinkering with, I haven't gotten it to work. Personally I can't tell if it's docker-py, the certs this swarm environment created, or my own handling here. Nonetheless, a start!