### PR TITLE
Fix default pool size in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Options:
   --pool_name                      Container name fragment used to identity
                                    containers that belong to this instance.
   --pool_size                      Capacity for containers on this system. Will
-                                   be prelaunched at startup. (default 128)
+                                   be prelaunched at startup. (default 10)
   --port                           port for the main server to listen on
                                    (default 9999)
   --redirect_uri                   URI to redirect users to upon initial


### PR DESCRIPTION
Default is listed as 128 in readme, but the actual default appears to be 10 (https://github.com/jupyter/tmpnb/blob/master/orchestrate.py#L144)