### PR TITLE
Handle null names response, update docker-py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ tmpnb: minimal-image tmpnb-image
 		--name=tmpnb \
 		-v /var/run/docker.sock:/docker.sock jupyter/tmpnb python orchestrate.py \
 		--image=jupyter/minimal --cull_timeout=$(CULL_TIMEOUT) --cull_period=$(CULL_PERIOD) \
-		--logging=$(LOGGING) --pool_size=$(POOL_SIZE) --static-files=/srv/ipython/IPython/html/static/
+		--logging=$(LOGGING) --pool_size=$(POOL_SIZE)
 
 dev: cleanup proxy tmpnb
 

--- a/dockworker.py
+++ b/dockworker.py
@@ -138,6 +138,9 @@ class DockerSpawner():
         def name_matches(container):
             try:
                 names = container['Names']
+                if names is None:
+                  app_log.warn("Docker API returned null Names, ignoring")
+                  return False
             except Exception:
                 app_log.warn("Invalid container: %r", container)
                 return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tornado==4.0.2
-docker-py==1.1.0
+docker-py==1.2.2
 pycurl==7.19.5
 futures==2.2.0
 pytz==2014.7


### PR DESCRIPTION
This updates docker-py and handles the Docker engine bug where it returns a null on `container["Names"]` instead of an empty list (or an error).