### PR TITLE
Catch request exceptions.

### DIFF
--- a/dockworker.py
+++ b/dockworker.py
@@ -164,7 +164,7 @@ class DockerSpawner():
                 del kwargs['max_tries']
             result = yield fn(*args, **kwargs)
             raise gen.Return(result)
-        except (docker.errors.APIError, requests.exceptions.ReadTimeout) as e:
+        except (docker.errors.APIError, requests.exceptions.RequestException) as e:
             app_log.error("Encountered a Docker error (%i retries remain): %s", max_tries, e)
             if max_tries > 0:
                 kwargs['max_tries'] = max_tries - 1


### PR DESCRIPTION
Now that I realize all of `requests.exceptions.*` inherit from `requests.exceptions.RequestException`, handle all the propagated errors from Docker daemon -> (docker-py/requests) -> tmpnb.