### PR TITLE
Bump docker py, updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,10 @@ tmpnb: minimal-image tmpnb-image
 		--image=jupyter/minimal --cull_timeout=$(CULL_TIMEOUT) --cull_period=$(CULL_PERIOD) \
 		--logging=$(LOGGING) --pool_size=$(POOL_SIZE)
 
-dev: cleanup proxy tmpnb
+dev: cleanup proxy tmpnb open
+
+open:
+	-open http://`echo $(DOCKER_HOST) | cut -d":" -f2`:8000
 
 cleanup:
 	-docker stop `docker ps -aq`

--- a/dockworker.py
+++ b/dockworker.py
@@ -165,7 +165,7 @@ class DockerSpawner():
             result = yield fn(*args, **kwargs)
             raise gen.Return(result)
         except (docker.errors.APIError, requests.exceptions.RequestException) as e:
-            app_log.error("Encountered a Docker error (%i retries remain): %s", max_tries, e)
+            app_log.error("Encountered a Docker error with {} ({} retries remain): {}".format(fn.__name__, max_tries, e))
             if max_tries > 0:
                 kwargs['max_tries'] = max_tries - 1
                 result = yield self._with_retries(fn, *args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tornado==4.0.2
-docker-py==1.2.2
+docker-py==1.2.3
 pycurl==7.19.5
 futures==2.2.0
 pytz==2014.7


### PR DESCRIPTION
This bumps docker py and provides some better error messaging.

This also includes a nifty little `make open` that will open the proxy server path for you. You'll likely need to reload to let tmpnb catch up with containers.

```
open http://`echo $(DOCKER_HOST) | cut -d":" -f2`:8000
```