### PR TITLE
Added BaseHandler with custom error pages to resolve #61

### DIFF
--- a/templates/error/404.html
+++ b/templates/error/404.html
@@ -1,0 +1,39 @@
+<html>
+<head>
+  <title>tmpnb</title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css">
+</head>
+<body>
+
+  <div class="jumbotron">
+    <div id="main" class="container text-center">
+      <h1>tmpnb</h1>
+      <div id="message">
+        <noscript>
+          <p>You'll need JavaScript enabled to enjoy this site!</p>
+        </noscript>
+
+        <div id="error-message">
+            <h2> Ah shucks! </h2>
+            <h3> Looks like the page you are looking for doesn't exist! </h3>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  
+    ga('create', 'UA-56096826-1', 'auto');
+    ga('require', 'displayfeatures');
+    ga('send', 'pageview');
+  </script>
+</body>
+</html>

--- a/templates/error/500.html
+++ b/templates/error/500.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+  <title>tmpnb</title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap-theme.min.css">
+</head>
+<body>
+
+  <div class="jumbotron">
+    <div id="main" class="container text-center">
+      <h1>tmpnb</h1>
+      <div id="message">
+        <noscript>
+          <p>You'll need JavaScript enabled to enjoy this site!</p>
+        </noscript>
+
+        <div id="error-message">
+            <h2> Ah shucks! </h2>
+            <h3> Looks like there was an error! </h3>
+            <h4> Error Code: {{status_code}} </h4>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  
+    ga('create', 'UA-56096826-1', 'auto');
+    ga('require', 'displayfeatures');
+    ga('send', 'pageview');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
I'm having a little bit of trouble getting the 404 error page to render properly. Looking at the Tornado docs, it looks like settings `default_handler_class` to `BaseHandler` and `default_handler_args` to `dict(status_code=404)` should do the trick but setting these values per the documentation results in a `Proxy target missing` error when loading up a non-existant location (http://localhost:8000/doesnotexist). 

I looked at the logs for the proxy container and saw the following whenever a request to a non-existent page was sent:
```
21:30:53.841 - error: [ConfigProxy] Proxy error:  code=ECONNRESET
21:30:54.923 - error: [ConfigProxy] Proxy error:  code=ECONNRESET
21:32:45.354 - error: [ConfigProxy] Proxy error:  code=ECONNRESET
```

Things I have tried:
1. Setting `BaseHandler` as a catch-all handler in the handlers list a-la `(r".*", BaseHandler)`
2. Creating a separate `NotFoundHandler` that inherits from `BaseHandler` that is set as the `default_handler_class`
3. Restarting the proxy container

All have not worked. I'm still researching the issue and trying to figure out what's up but I figured opening a pull request wouldn't hurt. 

This catches 500 errors fine. Let me know if there are any other specific error codes that require custom pages or if the error page needs to provide different info.