### PR TITLE
Handle kwargs_from_env and bump docker-py

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Options:
   --cull_timeout                   Timeout (s) for culling idle containers.
                                    (default 3600)
   --docker_version                 Version of the Docker API to use (default
-                                   1.13)
+                                   1.18)
   --help                           show this help information
   --image                          Docker container to spawn for new users.
                                    Must be on the system already (default

--- a/README.md
+++ b/README.md
@@ -53,13 +53,16 @@ docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN \
 Usage: orchestrate.py [OPTIONS]
 
 Options:
+
   --allow_origin                   Set the Access-Control-Allow-Origin header.
                                    Use '*' to allow any origin to access.
-                                   (default None)
+  --assert_hostname                Verify hostname of Docker daemon. (default
+                                   False)
   --command                        command to run when booting the image. A
                                    placeholder for base_path should be
-                                   provided. Example: "ipython notebook
-                                   --NotebookApp.base_url=/{base_path}"
+                                   provided. (default ipython notebook --no-
+                                   browser --port {port} --ip=0.0.0.0
+                                   --NotebookApp.base_url=/{base_path})
   --container_ip                   IP address for containers to bind to
                                    (default 127.0.0.1)
   --container_port                 Port for containers to bind to (default
@@ -70,11 +73,13 @@ Options:
   --cull_timeout                   Timeout (s) for culling idle containers.
                                    (default 3600)
   --docker_version                 Version of the Docker API to use (default
-                                   1.18)
+                                   1.13)
   --help                           show this help information
   --image                          Docker container to spawn for new users.
                                    Must be on the system already (default
                                    jupyter/minimal)
+  --ip                             ip for the main server to listen on
+                                   [default: all interfaces]
   --max_dock_workers               Maximum number of docker workers (default 2)
   --mem_limit                      Limit on Memory, per container (default
                                    512m)

--- a/dockworker.py
+++ b/dockworker.py
@@ -119,7 +119,7 @@ class DockerSpawner():
         app_log.info("Created container {}".format(container_id))
 
         port_bindings = {
-            container_config.container_port: ('0.0.0.0',)
+            container_config.container_port: (container_config.container_ip,)
         }
         yield self._with_retries(self.docker_client.start,
                                  container_id,

--- a/dockworker.py
+++ b/dockworker.py
@@ -109,7 +109,7 @@ class DockerSpawner():
         }
 
         host_config = dict(
-            #lxc_conf=lxc_conf
+            lxc_conf=lxc_conf
         )
 
         host_config = create_host_config(**host_config)

--- a/dockworker.py
+++ b/dockworker.py
@@ -48,20 +48,18 @@ class AsyncDockerClient():
 class DockerSpawner():
     def __init__(self,
                  docker_host='unix://var/run/docker.sock',
-                 version='1.12',
+                 version='1.18',
                  timeout=30,
                  max_workers=64):
 
-        kwargs = kwargs_from_env()
-        kwargs['tls'].assert_hostname = False
+        kwargs = kwargs_from_env(assert_hostname=False)
 
-        kwargs['version'] = '1.18'
+        # environment variable DOCKER_HOST takes precedence
+        kwargs.setdefault('base_url', docker_host)
 
-        blocking_docker_client = docker.Client(**kwargs)
-
-        #blocking_docker_client = docker.Client(base_url=docker_host,
-        #                                       version=version,
-        #                                       timeout=timeout)
+        blocking_docker_client = docker.Client(version=version,
+                                               timeout=timeout,
+                                               **kwargs)
 
         executor = ThreadPoolExecutor(max_workers=max_workers)
 

--- a/dockworker.py
+++ b/dockworker.py
@@ -55,6 +55,8 @@ class DockerSpawner():
         kwargs = kwargs_from_env()
         kwargs['tls'].assert_hostname = False
 
+        kwargs['version'] = '1.18'
+
         blocking_docker_client = docker.Client(**kwargs)
 
         #blocking_docker_client = docker.Client(base_url=docker_host,
@@ -107,7 +109,7 @@ class DockerSpawner():
         }
 
         host_config = dict(
-            lxc_conf=lxc_conf
+            #lxc_conf=lxc_conf
         )
 
         host_config = create_host_config(**host_config)
@@ -118,7 +120,8 @@ class DockerSpawner():
                                         host_config=host_config,
                                         name=container_name)
 
-        docker_warnings = resp['Warnings']
+        app_log.info(resp)
+        docker_warnings = resp.get('Warnings')
         if docker_warnings is not None:
             app_log.warn(docker_warnings)
 
@@ -126,7 +129,7 @@ class DockerSpawner():
         app_log.info("Created container {}".format(container_id))
 
         port_bindings = {
-            container_config.container_port: (container_config.container_ip,)
+            container_config.container_port: ('0.0.0.0',)
         }
         yield self._with_retries(self.docker_client.start,
                                  container_id,

--- a/dockworker.py
+++ b/dockworker.py
@@ -97,19 +97,8 @@ class DockerSpawner():
             rendered_command
         ]
 
-        lxc_conf = {
-            "cgroup" : {
-                "memory": {
-                    "limit_in_bytes": container_config.mem_limit
-                },
-                "cpu": {
-                    "shares": container_config.cpu_shares
-                }
-            }
-        }
-
         host_config = dict(
-            lxc_conf=lxc_conf
+            mem_limit=container_config.mem_limit
         )
 
         host_config = create_host_config(**host_config)
@@ -118,6 +107,7 @@ class DockerSpawner():
                                         image=container_config.image,
                                         command=command,
                                         host_config=host_config,
+                                        cpu_shares=int(container_config.cpu_shares),
                                         name=container_name)
 
         app_log.info(resp)

--- a/dockworker.py
+++ b/dockworker.py
@@ -108,7 +108,6 @@ class DockerSpawner():
                                         cpu_shares=int(container_config.cpu_shares),
                                         name=container_name)
 
-        app_log.info(resp)
         docker_warnings = resp.get('Warnings')
         if docker_warnings is not None:
             app_log.warn(docker_warnings)

--- a/dockworker.py
+++ b/dockworker.py
@@ -50,9 +50,11 @@ class DockerSpawner():
                  docker_host='unix://var/run/docker.sock',
                  version='1.18',
                  timeout=30,
-                 max_workers=64):
+                 max_workers=64,
+                 assert_hostname=False):
 
-        kwargs = kwargs_from_env(assert_hostname=False)
+        #kwargs = kwargs_from_env(assert_hostname=False)
+        kwargs = kwargs_from_env(assert_hostname=assert_hostname)
 
         # environment variable DOCKER_HOST takes precedence
         kwargs.setdefault('base_url', docker_host)

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -25,7 +25,7 @@ class LoadingHandler(RequestHandler):
         if self.allow_origin:
             self.set_header("Access-Control-Allow-Origin", self.allow_origin)
         self.render("loading.html", path=path)
-    
+
     @property
     def allow_origin(self):
         return self.settings['allow_origin']
@@ -184,6 +184,9 @@ def main():
     tornado.options.define('allow_origin', default=None,
         help="Set the Access-Control-Allow-Origin header. Use '*' to allow any origin to access."
     )
+    tornado.options.define('assert_hostname', default=False,
+        help="Verify hostname of Docker daemon. Defaults to false."
+    )
 
     tornado.options.parse_command_line()
     opts = tornado.options.options
@@ -219,6 +222,7 @@ def main():
                                        version=opts.docker_version,
                                        timeout=30,
                                        max_workers=opts.max_dock_workers,
+                                       assert_hostname=opts.assert_hostname,
     )
 
     static_path = os.path.join(os.path.dirname(__file__), "static")
@@ -267,7 +271,7 @@ def main():
                  opts.cull_period)
     culler = tornado.ioloop.PeriodicCallback(pool.heartbeat, cull_ms)
     culler.start()
-    
+
     app_log.info("Listening on {}:{}".format(opts.ip or '*', opts.port))
     application = tornado.web.Application(handlers, **settings)
     application.listen(opts.port, opts.ip)

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -185,7 +185,7 @@ def main():
         help="Set the Access-Control-Allow-Origin header. Use '*' to allow any origin to access."
     )
     tornado.options.define('assert_hostname', default=False,
-        help="Verify hostname of Docker daemon. Defaults to false."
+        help="Verify hostname of Docker daemon."
     )
 
     tornado.options.parse_command_line()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tornado==4.0.2
-docker-py==1.2.3
+docker-py==1.3.1
 pycurl==7.19.5
 futures==2.2.0
 pytz==2014.7


### PR DESCRIPTION
Docker py has a bunch of changes, one of which is using a `host_config` instead of direct mem limit setting.

I'm using tmpnb against swarm now and it was *much* easier to setup by pulling kwargs from env.

As I get this settled (and clean out some hardcoded gunk) we'll be well on our way to later versions of Docker.