### PR TITLE
Add --host_network option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,20 @@ Options:
                                    Use '*' to allow any origin to access.
   --assert_hostname                Verify hostname of Docker daemon. (default
                                    False)
-  --command                        command to run when booting the image. A
-                                   placeholder for base_path should be
-                                   provided. (default ipython notebook --no-
-                                   browser --port {port} --ip=0.0.0.0
+  --command                        Command to run when booting the image. A
+                                   placeholder for  {base_path} should be
+                                   provided. A placeholder for {port} and {ip}
+                                   can be  provided. (default ipython notebook
+                                   --no-browser --port {port} --ip=0.0.0.0
                                    --NotebookApp.base_url=/{base_path})
-  --container_ip                   IP address for containers to bind to
+  --container_ip                   Host IP address for containers to bind to.
+                                   If host_network=True, the IP
+                                   address for notebook servers to bind to.
                                    (default 127.0.0.1)
-  --container_port                 Port for containers to bind to (default
-                                   8888)
+  --container_port                 Within container port for notebook servers
+                                   to bind to.  If host_network=True, the
+                                   starting port assigned to notebook servers
+                                   on the host  network. (default 8888)
   --cpu_shares                     Limit CPU shares, per container
   --cull_period                    Interval (s) for culling idle containers.
                                    (default 600)
@@ -85,6 +90,11 @@ Options:
   --expose_headers                 Sets the Access-Control-Expose-Headers
                                    header.
   --help                           show this help information
+  --host_network                   Attaches the containers to the host
+                                   networking instead of the  default docker
+                                   bridge. Affects the semantics of
+                                   container_port and container_ip. (default
+                                   False)
   --image                          Docker container to spawn for new users.
                                    Must be on the system already (default
                                    jupyter/minimal)

--- a/dockworker.py
+++ b/dockworker.py
@@ -109,15 +109,6 @@ class DockerSpawner():
         rendered_command = container_config.command.format(base_path=base_path, port=port,
             ip=container_config.container_ip)
 
-        if container_config.host_network:
-            # Don't allow the notebook server to find another port: we won't be
-            # aware of it here and will wind up routing to the wrong server.
-            # Instead, let the server fail, the container die, and the cluster
-            # self-heal. Other possible approaches: find a free port here and
-            # assign it to the container (has a race condition), query the 
-            # running notebook config for its port (another race condition).
-            rendered_command += ' --NotebookApp.port_retries=0'
-
         command = [
             "/bin/sh",
             "-c",

--- a/dockworker.py
+++ b/dockworker.py
@@ -116,7 +116,7 @@ class DockerSpawner():
             # self-heal. Other possible approaches: find a free port here and
             # assign it to the container (has a race condition), query the 
             # running notebook config for its port (another race condition).
-            rendered_command += ' --NotebookApp.port_retries=0'.format(ip=container_config.container_ip)
+            rendered_command += ' --NotebookApp.port_retries=0'
 
         command = [
             "/bin/sh",

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -165,10 +165,12 @@ def main():
         help="Timeout (s) for culling idle containers."
     )
     tornado.options.define('container_ip', default='127.0.0.1',
-        help="IP address for containers to bind to"
+        help="""Host IP address for containers to bind to. If host_network=True,
+the host IP address for notebook servers to bind to."""
     )
     tornado.options.define('container_port', default='8888',
-        help="Port for containers to bind to"
+        help="""Within container port for notebook servers to bind to. 
+If host_network=True, the starting port assigned to notebook servers on the host."""
     )
 
     command_default = (
@@ -178,7 +180,8 @@ def main():
     )
 
     tornado.options.define('command', default=command_default,
-        help="command to run when booting the image. A placeholder for base_path should be provided."
+        help="""Command to run when booting the image. A placeholder for 
+{base_path} should be provided. A placeholder for {port} and {ip} can be provided."""
     )
     tornado.options.define('port', default=9999,
         help="port for the main server to listen on"
@@ -236,6 +239,9 @@ def main():
     )
     tornado.options.define('container_user', default=None,
         help="User to run container command as"
+    tornado.options.define('host_network', default=False,
+        help="""Attaches the containers to the host networking instead of the 
+default docker bridge. Affects the semantics of container_port and container_ip."""
     )
 
     tornado.options.parse_command_line()
@@ -269,6 +275,7 @@ def main():
         container_ip=opts.container_ip,
         container_port=opts.container_port,
         container_user=opts.container_user,
+        host_network=opts.host_network,
     )
 
     spawner = dockworker.DockerSpawner(docker_host,

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -177,6 +177,7 @@ If host_network=True, the starting port assigned to notebook servers on the host
         'ipython notebook --no-browser'
         ' --port {port} --ip=0.0.0.0'
         ' --NotebookApp.base_url=/{base_path}'
+        ' --NotebookApp.port_retries=0'
     )
 
     tornado.options.define('command', default=command_default,

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -240,6 +240,7 @@ If host_network=True, the starting port assigned to notebook servers on the host
     )
     tornado.options.define('container_user', default=None,
         help="User to run container command as"
+    )
     tornado.options.define('host_network', default=False,
         help="""Attaches the containers to the host networking instead of the 
 default docker bridge. Affects the semantics of container_port and container_ip."""


### PR DESCRIPTION
First cut at issue #169 :

* Update help strings
* Pick increasing host ports and let diagnosis heal cluster when port conflicts occur and containers instantly die. Don't try to find an open port within the spawner, race to launch a container, and assume it grabs it.
* Format {ip} if used in command template. Useful for specifying which host interface to bind to when in host network mode. (Default command never used it anyway and hard coded to 0.0.0.0 within the container)