### PR TITLE
Add container_user command line option

### DIFF
--- a/dockworker.py
+++ b/dockworker.py
@@ -11,7 +11,8 @@ from tornado import gen, web
 from tornado.log import app_log
 
 ContainerConfig = namedtuple('ContainerConfig', [
-    'image', 'command', 'mem_limit', 'cpu_shares', 'container_ip', 'container_port'
+    'image', 'command', 'mem_limit', 'cpu_shares', 'container_ip', 
+    'container_port', 'container_user'
 ])
 
 # Number of times to retry API calls before giving up.
@@ -111,6 +112,7 @@ class DockerSpawner():
 
         resp = yield self._with_retries(self.docker_client.create_container,
                                         image=container_config.image,
+                                        user=container_config.container_user,
                                         command=command,
                                         host_config=host_config,
                                         cpu_shares=cpu_shares,

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -234,6 +234,9 @@ def main():
     tornado.options.define('assert_hostname', default=False,
         help="Verify hostname of Docker daemon."
     )
+    tornado.options.define('container_user', default=None,
+        help="User to run container command as"
+    )
 
     tornado.options.parse_command_line()
     opts = tornado.options.options
@@ -265,6 +268,7 @@ def main():
         cpu_shares=opts.cpu_shares,
         container_ip=opts.container_ip,
         container_port=opts.container_port,
+        container_user=opts.container_user,
     )
 
     spawner = dockworker.DockerSpawner(docker_host,


### PR DESCRIPTION
Allow override of the default USER specified in the container image Dockerfile.

e.g., orchestrate.py --container_user=jovyan