### PR TITLE
Redirecting user to path specified in initial URL into tmpnb to resolve #155

### DIFF
--- a/templates/loading.html
+++ b/templates/loading.html
@@ -16,7 +16,7 @@
         </noscript>
 	
         <div id="websockets-ok">
-          {% if path %}
+          {% if is_user_path %}
           <p>The server you requested is no longer running or it doesn't exist.</p>
           {% end %}
           <p>Starting a new notebook server, just for you...<p>


### PR DESCRIPTION
This PR intends to resolve #155. It support redirecting to /notebooks or /tree urls.

If the user goes to 
```
http://127.0.0.1:8000/notebooks/some_notebook.ipynb
```

tmpnb will span a new container and redirect the user to 
```
http://127.0.0.1:8000/user/ABCDEFG/notebooks/some_notebook.ipynb
```