### PR TITLE
Do an initial cleanout if an old pool was around.

### DIFF
--- a/orchestrate.py
+++ b/orchestrate.py
@@ -315,6 +315,9 @@ def main():
         redirect_uri=opts.redirect_uri.lstrip('/'),
     )
 
+    # Cleanup on a fresh state (likely a restart)
+    ioloop.run_sync(pool.cleanout)
+
     # Synchronously cull any existing, inactive containers, and pre-launch a set number of
     # containers, ready to serve.
     ioloop.run_sync(pool.heartbeat)

--- a/spawnpool.py
+++ b/spawnpool.py
@@ -126,6 +126,26 @@ class SpawnPool():
                              len(running), self.capacity)
 
     @gen.coroutine
+    def cleanout(self):
+        '''Completely cleanout containers that are part of this pool.'''
+        print("Initial cleanup")
+        diagnosis = Diagnosis(self.max_age,
+                              self.spawner,
+                              self.container_name_pattern,
+                              self.proxy_endpoint,
+                              self.proxy_token)
+
+        yield diagnosis.observe()
+
+        try:
+            containers = yield self.spawner.list_notebook_servers(self.container_name_pattern, all=True)
+            routes = yield diagnosis._proxy_routes()
+            for container in containers:
+                yield self.spawner.shutdown_notebook_server(container['Id'])
+        except Exception as e:
+            print(e)
+
+    @gen.coroutine
     def heartbeat(self):
         '''Examine the pool for any missing, stopped, or idle containers, and replace them.
 

--- a/spawnpool.py
+++ b/spawnpool.py
@@ -128,22 +128,15 @@ class SpawnPool():
     @gen.coroutine
     def cleanout(self):
         '''Completely cleanout containers that are part of this pool.'''
-        print("Initial cleanup")
-        diagnosis = Diagnosis(self.max_age,
-                              self.spawner,
-                              self.container_name_pattern,
-                              self.proxy_endpoint,
-                              self.proxy_token)
+        app_log.info("Performing initial pool cleanup")
 
-        yield diagnosis.observe()
-
-        try:
-            containers = yield self.spawner.list_notebook_servers(self.container_name_pattern, all=True)
-            routes = yield diagnosis._proxy_routes()
-            for container in containers:
+        containers = yield self.spawner.list_notebook_servers(self.container_name_pattern, all=True)
+        for container in containers:
+            try:
+                app_log.debug("Clearing old container [%s] from pool", container['Id'])
                 yield self.spawner.shutdown_notebook_server(container['Id'])
-        except Exception as e:
-            print(e)
+            except Exception as e:
+                app_log.warn(e)
 
     @gen.coroutine
     def heartbeat(self):


### PR DESCRIPTION
This helps for restarts, where we expect that any running containers can't be trusted to just add back in the pool.