### PR TITLE
Fixed Makefile open command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ tmpnb: minimal-image tmpnb-image
 dev: cleanup proxy tmpnb open
 
 open:
-	-open http://`echo $(DOCKER_HOST) | cut -d":" -f2`:8000
+	-open http:`echo $(DOCKER_HOST) | cut -d":" -f2`:8000
 
 cleanup:
 	-docker stop `docker ps -aq`


### PR DESCRIPTION
This fixes a weird issue where the open command will open at `http://localhost/(ip_here)` instead of `http://(ip_here)`.