### PR TITLE
Admin server with DELETE /api/pool handler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ FROM ubuntu:14.04
 RUN apt-get update && apt-get upgrade -y && apt-get install python-pip python python-dev libcurl4-openssl-dev -y
 RUN pip install --upgrade pip
 
-RUN pip install tornado docker-py pycurl futures
+RUN mkdir -p /srv/tmpnb
+WORKDIR /srv/tmpnb/
+ADD requirements.txt /srv/tmpnb
+RUN pip install -r requirements.txt
 
 ADD . /srv/tmpnb/
-WORKDIR /srv/tmpnb/
 
 ENV DOCKER_HOST unix://docker.sock
-
-RUN pip install -r requirements.txt
 
 CMD python orchestrate.py

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN -v /var/run/docker.soc
 
 Note that if you do not pass a value to `docker-version`, tmpnb will automatically use the Docker API version provided by the server.
 
+The tmpnb server has two APIs: a public one that receives HTTP requests under the `/` proxy route and an administrative one available only on the private, localhost interface by default. You can configure the interfaces (`--ip`, `--admin_ip`) and ports (`--port`, `--admin_port`) of both APIs using command line arguments. If you decide to expose the admin API on a public interface, you can protect it by specifying a secret token as an environment variable `ADMIN_AUTH_TOKEN` when starting the `tmpnb` container. Thereafter, all requests made to the admin API must include it in an HTTP header like so:
+
+```
+Authorization: token <secret token here>
+```
+
+You can see the resources available in both APIs in the `orchestrate.py` file, but should  consider both to be unstable.
+
 #### Launching with *your own* Docker images
 
 tmpnb can run any Docker container provided by the `--image` option, so long as the `--command` option tells where the `{base_path}` and `{port}`. Those are literal strings, complete with curly braces that tmpnb will replace with an assigned `base_path` and `port`.
@@ -65,9 +73,12 @@ docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN \
 ```
 Usage: orchestrate.py [OPTIONS]
 
-Options:
+orchestrate.py options:
 
-
+  --admin-ip                       ip for the admin server to listen on
+                                   [default: 127.0.0.1] (default 127.0.0.1)
+  --admin-port                     port for the admin server to listen on
+                                   (default 10000)
   --allow-credentials              Sets the Access-Control-Allow-Credentials
                                    header.
   --allow-headers                  Sets the Access-Control-Allow-Headers
@@ -107,6 +118,8 @@ Options:
                                    volume, multiple         directories can be
                                    specified by using a comma-delimited string,
                                    directory         path must provided in full
+                                   (eg: /home/steve/data/:r), permissions
+                                   default to         rw
   --host-network                   Attaches the containers to the host
                                    networking instead of the  default docker
                                    bridge. Affects the semantics of

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -174,6 +174,35 @@ class APISpawnHandler(BaseHandler):
     def pool(self):
         return self.settings['pool']
 
+class AdminHandler(RequestHandler):
+    def prepare(self):
+        '''
+        Responds with a 401 error if the configured admin auth token is not 
+        present in the request headers.
+        '''
+        if self.admin_token:
+            client_token = self.request.headers.get('Authorization')
+            if client_token != 'token %s' % self.admin_token:
+                app_log.warn('rejecting admin request with token %s', client_token)
+                app_log.info('admin token: %s', self.admin_token)
+                return self.send_error(401)
+        return super(AdminHandler, self).prepare()
+
+    @property
+    def admin_token(self):
+        return self.settings['admin_token']
+
+class APIPoolHandler(AdminHandler):
+    @gen.coroutine
+    def delete(self):
+        '''Drains available containers from the pool.'''
+        yield self.pool.drain()
+        self.set_status(204)
+        self.finish()
+
+    @property
+    def pool(self):
+        return self.settings['pool']
 
 def main():
     tornado.options.define('cull_period', default=600,
@@ -207,6 +236,12 @@ If host_network=True, the starting port assigned to notebook servers on the host
     )
     tornado.options.define('ip', default=None,
         help="ip for the main server to listen on [default: all interfaces]"
+    )
+    tornado.options.define('admin_port', default=10000,
+        help="port for the admin server to listen on"
+    )
+    tornado.options.define('admin_ip', default='127.0.0.1',
+        help="ip for the admin server to listen on [default: 127.0.0.1]"
     )
     tornado.options.define('max_dock_workers', default=2,
         help="Maximum number of docker workers"
@@ -281,9 +316,14 @@ default docker bridge. Affects the semantics of container_port and container_ip.
         (r"/((?:notebooks|tree)(?:/.*)?)", LoadingHandler),
         (r"/api/stats/?", APIStatsHandler),
         (r"/stats/?", RedirectHandler, {"url": "/api/stats"}),
-        (r"/info/?", InfoHandler)
+        (r"/info/?", InfoHandler),
     ]
 
+    admin_handlers = [
+        (r"/api/pool/?", APIPoolHandler)
+    ]
+
+    admin_token = os.getenv('ADMIN_AUTH_TOKEN')
     proxy_token = os.environ['CONFIGPROXY_AUTH_TOKEN']
     proxy_endpoint = os.environ.get('CONFIGPROXY_ENDPOINT', "http://127.0.0.1:8001")
     docker_host = os.environ.get('DOCKER_HOST', 'unix://var/run/docker.sock')
@@ -350,6 +390,11 @@ default docker bridge. Affects the semantics of container_port and container_ip.
         redirect_uri=opts.redirect_uri.lstrip('/'),
     )
 
+    admin_settings = dict(
+        pool=pool,
+        admin_token=admin_token
+    )
+
     # Cleanup on a fresh state (likely a restart)
     ioloop.run_sync(pool.cleanout)
 
@@ -372,6 +417,11 @@ default docker bridge. Affects the semantics of container_port and container_ip.
     app_log.info("Listening on {}:{}".format(opts.ip or '*', opts.port))
     application = tornado.web.Application(handlers, **settings)
     application.listen(opts.port, opts.ip)
+
+    app_log.info("Admin listening on {}:{}".format(opts.admin_ip or '*', opts.admin_port))
+    admin_application = tornado.web.Application(admin_handlers, **admin_settings)
+    admin_application.listen(opts.admin_port, opts.admin_ip)
+
     ioloop.start()
 
 if __name__ == "__main__":

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -183,8 +183,7 @@ class AdminHandler(RequestHandler):
         if self.admin_token:
             client_token = self.request.headers.get('Authorization')
             if client_token != 'token %s' % self.admin_token:
-                app_log.warn('rejecting admin request with token %s', client_token)
-                app_log.info('admin token: %s', self.admin_token)
+                app_log.warn('Rejecting admin request with token %s', client_token)
                 return self.send_error(401)
         return super(AdminHandler, self).prepare()
 
@@ -196,9 +195,9 @@ class APIPoolHandler(AdminHandler):
     @gen.coroutine
     def delete(self):
         '''Drains available containers from the pool.'''
-        yield self.pool.drain()
-        self.set_status(204)
-        self.finish()
+        n = yield self.pool.drain()
+        app_log.info('Drained pool of %d containers', n)
+        self.finish(dict(drained=n))
 
     @property
     def pool(self):

--- a/spawnpool.py
+++ b/spawnpool.py
@@ -143,7 +143,8 @@ class SpawnPool():
         '''
         Completely cleanout all available containers in the pool and immediately
         schedule their replacement. Useful for refilling the pool with a new 
-        container image while leaving in-use containers untouched.
+        container image while leaving in-use containers untouched. Returns the
+        number of containers drained.
         '''
         app_log.info("Draining available containers from pool")
         tasks = []
@@ -156,6 +157,7 @@ class SpawnPool():
                 # No more free containers left to acquire
                 break
         yield tasks
+        raise gen.Return(len(tasks))
 
     @gen.coroutine
     def heartbeat(self):


### PR DESCRIPTION
Use case: I want to `docker pull` or `docker build` a new container image on the tmpnb box. I don't want containers already in the pool based on the old image to linger indefinitely until they are used up. I want to immediately drain the pool of idle, available containers and replenish the pool with containers from the new image. While doing so, I do not want to disturb containers that are currently in-use. In practice, I should be able to do something as simple as:

```
eval `docker-machine env my-tmpnb-host`
docker build -t my-notebook-image .
docker exec -i tmpnb-pool curl -X "DELETE" http://127.0.0.1:10000/api/pool
```

to get the desired effect.

Since pool draining is a costly operation, this PR adds a new "admin" server that listens on a port separate from the main tmpnb server. The admin server only listens on localhost by default and supports an optional `ADMIN_AUTH_TOKEN` env var as a shared-secret client authorization mechanism. 

The admin server currently implements a single handler for `DELETE /api/pool` that implements the behavior described above. However, it can grow to support other admin operations in the future (e.g., PUT to change config settings like total number containers in the pool).

I'm open to other verbs and resource names. `DELETE /api/pool` was the first thing that came to mind.