### PR TITLE
Don't replace containers immediately when draining

### DIFF
--- a/spawnpool.py
+++ b/spawnpool.py
@@ -152,7 +152,7 @@ class SpawnPool():
             try:
                 pooled = self.acquire()
                 app_log.debug("Releasing container [%s] to drain the pool.", pooled.id)
-                tasks.append(self.release(pooled, True))
+                tasks.append(self.release(pooled, replace_if_room=False))
             except EmptyPoolError:
                 # No more free containers left to acquire
                 break


### PR DESCRIPTION
Let the next heartbeat task detect that containers are missing and handle their replacement. Replacing immediately leads to chaos when the heartbeat goes off in the middle of the asynchronous drains. For example:

<img width="818" alt="screen shot 2015-12-28 at 9 28 03 pm" src="https://cloud.githubusercontent.com/assets/153745/12028724/3623a062-adaa-11e5-95dd-f9ca5ec31403.png">

Notice the number of containers doubles after a drain on the left side of the graph (before this fix). There's no overshoot after the drain on the right side of the graph (after this fix).