### PR TITLE
Support token auth for /api/* resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,17 @@ docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN -v /var/run/docker.soc
 
 Note that if you do not pass a value to `docker-version`, tmpnb will automatically use the Docker API version provided by the server.
 
-The tmpnb server has two APIs: a public one that receives HTTP requests under the `/` proxy route and an administrative one available only on the private, localhost interface by default. You can configure the interfaces (`--ip`, `--admin_ip`) and ports (`--port`, `--admin_port`) of both APIs using command line arguments. If you decide to expose the admin API on a public interface, you can protect it by specifying a secret token as an environment variable `ADMIN_AUTH_TOKEN` when starting the `tmpnb` container. Thereafter, all requests made to the admin API must include it in an HTTP header like so:
+The tmpnb server has two APIs: a public one that receives HTTP requests under the `/` proxy route and an administrative one available only on the private, localhost interface by default. You can configure the interfaces (`--ip`, `--admin_ip`) and ports (`--port`, `--admin_port`) of both APIs using command line arguments. 
+
+If you decide to expose the admin API on a public interface, you can protect it by specifying a secret token in the environment variable `ADMIN_AUTH_TOKEN` when starting the `tmpnb` container. Thereafter, all requests made to the admin API must include it in an HTTP header like so:
 
 ```
-Authorization: token <secret token here>
+Authorization: token <admin secret token here>
 ```
 
-You can see the resources available in both APIs in the `orchestrate.py` file, but should  consider both to be unstable.
+Likewise, if you only want to allow programmatic access to your tmpnb cluster by select clients, you can specify a separate secret token in the environment variable `API_AUTH_TOKEN` when starting the `tmpnb` container. All requests made to the public API must include it in an HTTP header in the same manner as depicted for the admin token above. Note that when this token is set, only the `/api/*` resources of the tmpnb server are available. All human-facing paths are disabled.
+
+If you want to see the resources available in both the admin and user APIs, look at the handler paths registered in the `orchestrate.py` file. You should consider both APIs to be unstable.
 
 #### Launching with *your own* Docker images
 

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -48,6 +48,12 @@ class BaseHandler(RequestHandler):
         if self.allow_headers:
             self.set_header("Access-Control-Allow-Headers", self.allow_headers)
 
+        # Confirm the client authorization token if an api token is configured
+        if self.api_token is not None:
+            client_token = self.request.headers.get('Authorization')
+            if client_token != 'token %s' % self.api_token:
+                return self.send_error(401)
+
     @property
     def allow_origin(self):
         return self.settings['allow_origin']
@@ -72,6 +78,10 @@ class BaseHandler(RequestHandler):
     def allow_headers(self):
         return self.settings['allow_headers']
 
+    @property
+    def api_token(self):
+        return self.settings['api_token']
+    
 class LoadingHandler(BaseHandler):
     def get(self, path=None):
         self.render("loading.html", is_user_path=self.is_user_path(path))
@@ -306,26 +316,32 @@ default docker bridge. Affects the semantics of container_port and container_ip.
     tornado.options.parse_command_line()
     opts = tornado.options.options
 
-    handlers = [
-        (r"/", LoadingHandler),
-        (r"/spawn/?(/user/\w+(?:/.*)?)?", SpawnHandler),
-        (r"/spawn/((?:notebooks|tree)(?:/.*)?)", SpawnHandler),
-        (r"/api/spawn/?", APISpawnHandler),
-        (r"/(user/\w+)(?:/.*)?", LoadingHandler),
-        (r"/((?:notebooks|tree)(?:/.*)?)", LoadingHandler),
-        (r"/api/stats/?", APIStatsHandler),
-        (r"/stats/?", RedirectHandler, {"url": "/api/stats"}),
-        (r"/info/?", InfoHandler),
-    ]
-
-    admin_handlers = [
-        (r"/api/pool/?", APIPoolHandler)
-    ]
-
+    api_token = os.getenv('API_AUTH_TOKEN')
     admin_token = os.getenv('ADMIN_AUTH_TOKEN')
     proxy_token = os.environ['CONFIGPROXY_AUTH_TOKEN']
     proxy_endpoint = os.environ.get('CONFIGPROXY_ENDPOINT', "http://127.0.0.1:8001")
     docker_host = os.environ.get('DOCKER_HOST', 'unix://var/run/docker.sock')
+
+    handlers = [
+        (r"/api/spawn/?", APISpawnHandler),
+        (r"/api/stats/?", APIStatsHandler)
+    ]
+
+    # Only add human-facing handlers if there's no spawn API key set
+    if api_token is None:
+        handlers.extend([
+            (r"/", LoadingHandler),
+            (r"/spawn/?(/user/\w+(?:/.*)?)?", SpawnHandler),
+            (r"/spawn/((?:notebooks|tree)(?:/.*)?)", SpawnHandler),
+            (r"/(user/\w+)(?:/.*)?", LoadingHandler),
+            (r"/((?:notebooks|tree)(?:/.*)?)", LoadingHandler),  
+            (r"/stats/?", RedirectHandler, {"url": "/api/stats"}),
+            (r"/info/?", InfoHandler),
+        ])
+
+    admin_handlers = [
+        (r"/api/pool/?", APIPoolHandler)
+    ]
 
     max_age = datetime.timedelta(seconds=opts.cull_timeout)
     pool_name = opts.pool_name
@@ -384,6 +400,7 @@ default docker bridge. Affects the semantics of container_port and container_ip.
         pool=pool,
         autoescape=None,
         proxy_token=proxy_token,
+        api_token=api_token,
         template_path=os.path.join(os.path.dirname(__file__), 'templates'),
         proxy_endpoint=proxy_endpoint,
         redirect_uri=opts.redirect_uri.lstrip('/'),


### PR DESCRIPTION
* Accept optional API key from API_AUTH_TOKEN env var
* Disable human-facing handlers when API token is provided
* Check API token in BaseHandler
* Update README

Fixes #189 