### PR TITLE
Make /user/:id length configurable, secure

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ orchestrate.py options:
                                    notebook launch (default /tree)
   --static-files                   Static files to extract from the initial
                                    container launch
+  --user_length                    Length of the unique /user/:id path
+                                   generated per container (default 12)
 ```
 
 #### Development

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -302,6 +302,9 @@ default docker bridge. Affects the semantics of container_port and container_ip.
         directories can be specified by using a comma-delimited string, directory
         path must provided in full (eg: /home/steve/data/:r), permissions default to
         rw""")
+    tornado.options.define('user_length', default=12,
+        help="Length of the unique /user/:id path generated per container"
+    )
 
     tornado.options.parse_command_line()
     opts = tornado.options.options
@@ -363,6 +366,7 @@ default docker bridge. Affects the semantics of container_port and container_ip.
                                static_files=opts.static_files,
                                static_dump_path=static_path,
                                pool_name=pool_name,
+                               user_length=opts.user_length
     )
 
     ioloop = tornado.ioloop.IOLoop().instance()

--- a/spawnpool.py
+++ b/spawnpool.py
@@ -21,15 +21,15 @@ import dockworker
 AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
 
 
-def sample_with_replacement(a, size=12):
+def sample_with_replacement(a, size):
     '''Get a random path. If Python had sampling with replacement built in,
     I would use that. The other alternative is numpy.random.choice, but
     numpy is overkill for this tiny bit of random pathing.'''
-    return "".join([random.choice(a) for x in range(size)])
+    return "".join([random.SystemRandom().choice(a) for x in range(size)])
 
 
-def new_user():
-    return sample_with_replacement(string.ascii_letters + string.digits)
+def new_user(size):
+    return sample_with_replacement(string.ascii_letters + string.digits, size)
 
 
 PooledContainer = namedtuple('PooledContainer', ['id', 'path'])
@@ -52,6 +52,7 @@ class SpawnPool():
                  capacity,
                  max_age,
                  pool_name,
+                 user_length,
                  static_files=None,
                  static_dump_path=os.path.join(os.path.dirname(__file__),
                                                "static")):
@@ -67,6 +68,8 @@ class SpawnPool():
 
         self.proxy_endpoint = proxy_endpoint
         self.proxy_token = proxy_token
+
+        self.user_length = user_length
 
         self.available = deque()
 
@@ -243,7 +246,7 @@ class SpawnPool():
         add it to the pool.'''
 
         if user is None:
-            user = new_user()
+            user = new_user(self.user_length)
 
         path = "user/" + user
 


### PR DESCRIPTION
* Use SystemRandom for character choice
* Let user configure the desired length of the user ID

Compliments #204. If you specify an API_AUTH_TOKEN on tmpnb start, only clients that know the token can request access to a container via `/api/spawn`. The spawn response contains the `/user/:id` path of a selected container. If you specify a reasonably long `user_length` on tmpnb start, guessing the path to a spawned container becomes very difficult. In essence, the path segment winds up acting like an API key to the container.

Not rock solid security, but, hey, not bad reusing what already exists.