### PR TITLE
tornado/py3 compat

### DIFF
--- a/orchestrate.py
+++ b/orchestrate.py
@@ -385,7 +385,7 @@ default docker bridge. Affects the semantics of container_port and container_ip.
                                user_length=opts.user_length
     )
 
-    ioloop = tornado.ioloop.IOLoop().instance()
+    ioloop = tornado.ioloop.IOLoop().current()
 
     settings = dict(
         default_handler_class=BaseHandler,

--- a/spawnpool.py
+++ b/spawnpool.py
@@ -204,8 +204,8 @@ class SpawnPool():
             # Normalize the container count to its initial capacity by scheduling deletions if we're
             # over or scheduling launches if we're under.
             current = len(diagnosis.living_container_ids)
-            under = xrange(current, self.capacity)
-            over = xrange(self.capacity, current)
+            under = range(current, self.capacity)
+            over = range(self.capacity, current)
 
             if under:
                 app_log.debug("Launching [%i] new containers to populate the pool.", len(under))


### PR DESCRIPTION
- use builtin range
- use IOLoop.current instead of instance