### PR TITLE
Extending Quick Start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN --name=proxy jupyter/c
 docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN --name=tmpnb -v /var/run/docker.sock:/docker.sock jupyter/tmpnb
 ```
 
-BAM! Visit your host on port 8000 and you have a working tmpnb setup. The ` -v /var/run/docker.sock:/docker.sock` bit causes the orchestrator container to mount the docker client, which allows the orchestrator container to spawn docker containers on the host (see [this article](http://nathanleclaire.com/blog/2014/07/12/10-docker-tips-and-tricks-that-will-make-you-sing-a-whale-song-of-joy/#bind-mount-the-docker-socket-on-docker-run:1765430f0793020845eca6c8326a4e45) for more information).  Note, if you are using boot2docker, then you can find your docker host's ip address by running the following command in your console:
+BAM! Visit your Docker host on port 8000 and you have a working tmpnb setup. The ` -v /var/run/docker.sock:/docker.sock` bit causes the orchestrator container to mount the docker client, which allows the orchestrator container to spawn docker containers on the host (see [this article](http://nathanleclaire.com/blog/2014/07/12/10-docker-tips-and-tricks-that-will-make-you-sing-a-whale-song-of-joy/#bind-mount-the-docker-socket-on-docker-run:1765430f0793020845eca6c8326a4e45) for more information).
 
-```
-boot2docker ip
-```
+If you are running docker using docker-machine, as is now the standard, get the IP address of your Docker host by running `docker-machine ls`. If you are using boot2docker, then you can find your docker host's ip address by running the following command in your console: `boot2docker ip`
 
 If it didn't come up, try running `docker ps -a` and `docker logs tmpnb` to help diagnose issues.
 


### PR DESCRIPTION
I think this makes the usage instructions slightly clearer to people like me who didn't know Docker before we started trying to use this project :)

Adding the reference to `docker-machine` would also have been useful to me.

I think this would be a valuable addition to the README if it's using correct terminology, which I'm still not sure about.