### PR TITLE
Bump all of our dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.4-wheezy
 
-RUN apt-get update && apt-get upgrade -y && apt-get install python-pip python python-dev libcurl4-openssl-dev -y
+RUN apt-get update && apt-get install python-dev libcurl4-openssl-dev -y
 RUN pip install --upgrade pip
 
 RUN mkdir -p /srv/tmpnb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM python:3.4-wheezy
 
 RUN apt-get update && apt-get upgrade -y && apt-get install python-pip python python-dev libcurl4-openssl-dev -y
 RUN pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ tmpnb: minimal-image tmpnb-image
 dev: cleanup proxy tmpnb open
 
 open:
+	docker ps | grep tmpnb
+	docker ps | grep minimal-notebook
 	-open http:`echo $(DOCKER_HOST) | cut -d":" -f2`:8000
 
 cleanup:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-tornado==4.0.2
-docker-py==1.3.1
-pycurl==7.19.5
-futures==2.2.0
-pytz==2014.7
+tornado==4.3.0
+docker-py==1.7.1
+pycurl==7.43.0
+futures==3.0.5
+pytz==2015.7


### PR DESCRIPTION
In order for me to bring in the automated networking support (as well as use current versions of Docker), we need up to date dependencies.

Currently trying this out and will remove the WIP tag when ready.