### PR TITLE
Add extra-hosts command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ orchestrate.py options:
                                    auto)
   --expose-headers                 Sets the Access-Control-Expose-Headers
                                    header.
+  --extra-hosts                    Extra hosts for the containers, multiple
+                                   hosts can be specified         by using a
+                                   comma-delimited string, specified in the
+                                   form hostname:IP (default [])
   --host-directories               Mount the specified directory as a data
                                    volume, multiple         directories can be
                                    specified by using a comma-delimited string,

--- a/dockworker.py
+++ b/dockworker.py
@@ -12,7 +12,8 @@ from tornado.log import app_log
 
 ContainerConfig = namedtuple('ContainerConfig', [
     'image', 'command', 'mem_limit', 'cpu_shares', 'container_ip', 
-    'container_port', 'container_user', 'host_network', 'host_directories'
+    'container_port', 'container_user', 'host_network', 'host_directories',
+    'extra_hosts'
 ])
 
 # Number of times to retry API calls before giving up.
@@ -132,11 +133,15 @@ class DockerSpawner():
                     'mode': permissions
                 }
 
+        extra_hosts = dict(map(lambda h: tuple(h.split(':')),
+                               container_config.extra_hosts))
+
         host_config = dict(
             mem_limit=container_config.mem_limit,
             network_mode='host' if container_config.host_network else 'bridge',
             binds=volume_bindings,
-            port_bindings=port_bindings
+            port_bindings=port_bindings,
+            extra_hosts=extra_hosts
         )
 
         host_config = create_host_config(**host_config)

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -320,6 +320,9 @@ default docker bridge. Affects the semantics of container_port and container_ip.
     tornado.options.define('user_length', default=12,
         help="Length of the unique /user/:id path generated per container"
     )
+    tornado.options.define('extra_hosts', default=[], multiple=True,
+        help="""Extra hosts for the containers, multiple hosts can be specified
+        by using a comma-delimited string, specified in the form hostname:IP""")
 
     tornado.options.parse_command_line()
     opts = tornado.options.options
@@ -366,7 +369,8 @@ default docker bridge. Affects the semantics of container_port and container_ip.
         container_port=opts.container_port,
         container_user=opts.container_user,
         host_network=opts.host_network,
-        host_directories=opts.host_directories
+        host_directories=opts.host_directories,
+        extra_hosts=opts.extra_hosts
     )
 
     spawner = dockworker.DockerSpawner(docker_host,


### PR DESCRIPTION
Allow to set extra-hosts parameter to Jupyter container.

We would like to set hostname-ip pairs for our private servers to the notebook containers... like `docker run --add-host host:ip` command. 