### PR TITLE
Forwarded docker-py version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tornado==4.3.0
-docker-py==1.7.1
+docker-py==1.7.2
 pycurl==7.43.0
 futures==3.0.5
 pytz==2015.7


### PR DESCRIPTION
docker-py 1.7.1 has a bug in TLS connection code
This bug is relevant when running tmpnb on docker swarm
-> forwarded version from 1.7.1 to 1.7.2