### PR TITLE
Delete the gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ## tmpnb, the temporary notebook service
 
-[![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/jupyter/tmpnb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 Launches "temporary" Jupyter notebook servers.
 
 ![tmpnb architecture](https://cloud.githubusercontent.com/assets/836375/5911140/c53e3978-a587-11e4-86a5-695469ef23a5.png)


### PR DESCRIPTION
Not very many of us seem to be watching the gitter channel and we tend to divert to issues here. I'd like to remove the gitter channel mention from the repo itself.