### PR TITLE
add cull-max for hard upper limit for container age

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 # Configuration parameters
 CULL_PERIOD ?= 30
 CULL_TIMEOUT ?= 60
+CULL_MAX ?= 120
 LOGGING ?= debug
 POOL_SIZE ?= 5
+DOCKER_HOST ?= 127.0.0.1
 
 tmpnb-image: Dockerfile
 	docker build -t jupyter/tmpnb .
@@ -29,7 +31,7 @@ tmpnb: minimal-image tmpnb-image
 		--name tmpnb \
 		-v /var/run/docker.sock:/docker.sock jupyter/tmpnb python orchestrate.py \
 		--image=jupyter/minimal-notebook --cull_timeout=$(CULL_TIMEOUT) --cull_period=$(CULL_PERIOD) \
-		--logging=$(LOGGING) --pool_size=$(POOL_SIZE)
+		--logging=$(LOGGING) --pool_size=$(POOL_SIZE) --cull_max=$(CULL_MAX)
 
 dev: cleanup proxy tmpnb open
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,35 @@ docker run -d \
 ```
 Usage: orchestrate.py [OPTIONS]
 
+Options:
+
+  --help                           show this help information
+
+tornado/log.py options:
+
+  --log-file-max-size              max size of log files before rollover
+                                   (default 100000000)
+  --log-file-num-backups           number of log files to keep (default 10)
+  --log-file-prefix=PATH           Path prefix for log files. Note that if you
+                                   are running multiple tornado processes,
+                                   log_file_prefix must be different for each
+                                   of them (e.g. include the port number)
+  --log-rotate-interval            The interval value of timed rotating
+                                   (default 1)
+  --log-rotate-mode                The mode of rotating files(time or size)
+                                   (default size)
+  --log-rotate-when                specify the type of TimedRotatingFileHandler
+                                   interval other options:('S', 'M', 'H', 'D',
+                                   'W0'-'W6') (default midnight)
+  --log-to-stderr                  Send log output to stderr (colorized if
+                                   possible). By default use stderr if
+                                   --log_file_prefix is not set and no other
+                                   logging is configured.
+  --logging=debug|info|warning|error|none
+                                   Set the Python log level. If 'none', tornado
+                                   won't touch the logging configuration.
+                                   (default info)
+
 orchestrate.py options:
 
   --admin-ip                       ip for the admin server to listen on
@@ -97,7 +126,7 @@ orchestrate.py options:
   --assert-hostname                Verify hostname of Docker daemon. (default
                                    False)
   --command                        Command to run when booting the image. A
-                                   placeholder for  {base_path} should be
+                                   placeholder for {base_path} should be
                                    provided. A placeholder for {port} and {ip}
                                    can be provided. (default jupyter notebook
                                    --no-browser --port {port} --ip=0.0.0.0
@@ -108,11 +137,21 @@ orchestrate.py options:
                                    for notebook servers to bind to. (default
                                    127.0.0.1)
   --container-port                 Within container port for notebook servers
-                                   to bind to.  If host_network=True, the
+                                   to bind to. If host_network=True, the
                                    starting port assigned to notebook servers
                                    on the host. (default 8888)
   --container-user                 User to run container command as
+  --cpu-quota                      Limit CPU quota, per container.
+                                   Units are CPU-µs per 100ms, so 1
+                                   CPU/container would be:
+                                   --cpu-quota=100000
   --cpu-shares                     Limit CPU shares, per container
+  --cull-max                       Maximum age of a container (s), regardless
+                                   of activity.                  Default: 14400
+                                   (4 hours)                  A container that
+                                   has been running for this long will be
+                                   culled,         even if it is not idle.
+                                   (default 14400)
   --cull-period                    Interval (s) for culling idle containers.
                                    (default 600)
   --cull-timeout                   Timeout (s) for culling idle containers.
@@ -132,13 +171,13 @@ orchestrate.py options:
                                    (eg: /home/steve/data/:r), permissions
                                    default to         rw
   --host-network                   Attaches the containers to the host
-                                   networking instead of the  default docker
+                                   networking instead of the default docker
                                    bridge. Affects the semantics of
                                    container_port and container_ip. (default
                                    False)
   --image                          Docker container to spawn for new users.
                                    Must be on the system already (default
-                                   jupyter/minimal)
+                                   jupyter/minimal-notebook)
   --ip                             ip for the main server to listen on
                                    [default: all interfaces]
   --max-age                        Sets the Access-Control-Max-Age header.
@@ -155,7 +194,7 @@ orchestrate.py options:
                                    notebook launch (default /tree)
   --static-files                   Static files to extract from the initial
                                    container launch
-  --user_length                    Length of the unique /user/:id path
+  --user-length                    Length of the unique /user/:id path
                                    generated per container (default 12)
 ```
 

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -225,6 +225,15 @@ def main():
     tornado.options.define('cull_timeout', default=3600,
         help="Timeout (s) for culling idle containers."
     )
+    tornado.options.define('cull_max', default=14400,
+        help="""Maximum age of a container (s), regardless of activity.
+        
+        Default: 14400 (4 hours)
+        
+        A container that has been running for this long will be culled,
+        even if it is not idle.
+        """
+    )
     tornado.options.define('container_ip', default='127.0.0.1',
         help="""Host IP address for containers to bind to. If host_network=True,
 the host IP address for notebook servers to bind to."""
@@ -363,6 +372,7 @@ default docker bridge. Affects the semantics of container_port and container_ip.
         (r"/api/pool/?", APIPoolHandler)
     ]
 
+    max_idle = datetime.timedelta(seconds=opts.cull_timeout)
     max_age = datetime.timedelta(seconds=opts.cull_timeout)
     pool_name = opts.pool_name
     if pool_name is None:
@@ -397,6 +407,7 @@ default docker bridge. Affects the semantics of container_port and container_ip.
                                spawner=spawner,
                                container_config=container_config,
                                capacity=opts.pool_size,
+                               max_idle=max_idle,
                                max_age=max_age,
                                static_files=opts.static_files,
                                static_dump_path=static_path,

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -5,6 +5,7 @@ import datetime
 import json
 import os
 import re
+from textwrap import dedent
 import uuid
 
 from concurrent.futures import ThreadPoolExecutor
@@ -226,13 +227,14 @@ def main():
         help="Timeout (s) for culling idle containers."
     )
     tornado.options.define('cull_max', default=14400,
-        help="""Maximum age of a container (s), regardless of activity.
-        
+        help=dedent("""
+        Maximum age of a container (s), regardless of activity.
+
         Default: 14400 (4 hours)
-        
+
         A container that has been running for this long will be culled,
         even if it is not idle.
-        """
+        """)
     )
     tornado.options.define('container_ip', default='127.0.0.1',
         help="""Host IP address for containers to bind to. If host_network=True,
@@ -276,13 +278,14 @@ If host_network=True, the starting port assigned to notebook servers on the host
         help="Limit CPU shares, per container"
     )
     tornado.options.define('cpu_quota', default=None, type=int,
-        help=u"""Limit CPU quota, per container.
+        help=dedent("""
+        Limit CPU quota, per container.
         
         Units are CPU-µs per 100ms, so 1 CPU/container would be:
         
             --cpu-quota=100000
         
-        """
+        """)
     )
     tornado.options.define('image', default="jupyter/minimal-notebook",
         help="Docker container to spawn for new users. Must be on the system already"
@@ -331,16 +334,18 @@ If host_network=True, the starting port assigned to notebook servers on the host
 default docker bridge. Affects the semantics of container_port and container_ip."""
     )
     tornado.options.define('host_directories', default=None,
-        help="""Mount the specified directory as a data volume, multiple
+        help=dedent("""
+        Mount the specified directory as a data volume, multiple
         directories can be specified by using a comma-delimited string, directory
         path must provided in full (eg: /home/steve/data/:r), permissions default to
-        rw""")
+        rw"""))
     tornado.options.define('user_length', default=12,
         help="Length of the unique /user/:id path generated per container"
     )
     tornado.options.define('extra_hosts', default=[], multiple=True,
-        help="""Extra hosts for the containers, multiple hosts can be specified
-        by using a comma-delimited string, specified in the form hostname:IP""")
+        help=dedent("""
+        Extra hosts for the containers, multiple hosts can be specified
+        by using a comma-delimited string, specified in the form hostname:IP"""))
 
     tornado.options.parse_command_line()
     opts = tornado.options.options


### PR DESCRIPTION
This limits how long a container can be used, so that a forgotten browser tab or a user cannot squat a container for too long.

Default is four hours

This doesn't work as intended just yet, because containers are currently added to the proxy at launch, meaning that the timer starts when the container is created, not when it is popped out of the pool.