### PR TITLE
allow using docker networks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ CULL_PERIOD ?= 30
 CULL_TIMEOUT ?= 60
 CULL_MAX ?= 120
 LOGGING ?= debug
-POOL_SIZE ?= 5
+POOL_SIZE ?= 1
 DOCKER_HOST ?= 127.0.0.1
+DOCKER_NETWORK_NAME ?= tmpnb
 
 tmpnb-image: Dockerfile
 	docker build -t jupyter/tmpnb .
@@ -20,24 +21,32 @@ demo-image:
 proxy-image:
 	docker pull jupyter/configurable-http-proxy
 
-proxy: proxy-image
-	docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=devtoken \
+network:
+	@docker network inspect $(DOCKER_NETWORK_NAME) >/dev/null 2>&1 || docker network create $(DOCKER_NETWORK_NAME)
+
+proxy: proxy-image network
+	docker run -d -e CONFIGPROXY_AUTH_TOKEN=devtoken \
+		--network $(DOCKER_NETWORK_NAME) \
+		-p 8000:8000 \
+		-p 8001:8001 \
 		--name proxy \
 		jupyter/configurable-http-proxy \
-		--default-target http://127.0.0.1:9999
+		--default-target http://tmpnb:9999 --api-ip 0.0.0.0
 
-tmpnb: minimal-image tmpnb-image
-	docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=devtoken \
+tmpnb: minimal-image tmpnb-image network
+	docker run -d -e CONFIGPROXY_AUTH_TOKEN=devtoken \
+		-e CONFIGPROXY_ENDPOINT=http://proxy:8001 \
+		--network $(DOCKER_NETWORK_NAME) \
 		--name tmpnb \
 		-v /var/run/docker.sock:/docker.sock jupyter/tmpnb python orchestrate.py \
 		--image=jupyter/minimal-notebook --cull_timeout=$(CULL_TIMEOUT) --cull_period=$(CULL_PERIOD) \
-		--logging=$(LOGGING) --pool_size=$(POOL_SIZE) --cull_max=$(CULL_MAX)
+		--logging=$(LOGGING) --pool_size=$(POOL_SIZE) --cull_max=$(CULL_MAX) \
+		--docker_network=$(DOCKER_NETWORK_NAME)
 
-dev: cleanup proxy tmpnb open
+dev: cleanup network proxy tmpnb open
 
 open:
 	docker ps | grep tmpnb
-	docker ps | grep minimal-notebook
 	-open http:`echo $(DOCKER_HOST) | cut -d":" -f2`:8000
 
 cleanup:

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -333,6 +333,10 @@ If host_network=True, the starting port assigned to notebook servers on the host
         help="""Attaches the containers to the host networking instead of the
 default docker bridge. Affects the semantics of container_port and container_ip."""
     )
+    tornado.options.define('docker_network', default=None,
+        help="""Attaches the containers to the specified docker network.
+        For use when the proxy, tmpnb, and containers are all in docker."""
+    )
     tornado.options.define('host_directories', default=None,
         help=dedent("""
         Mount the specified directory as a data volume, multiple
@@ -394,6 +398,7 @@ default docker bridge. Affects the semantics of container_port and container_ip.
         container_port=opts.container_port,
         container_user=opts.container_user,
         host_network=opts.host_network,
+        docker_network=opts.docker_network,
         host_directories=opts.host_directories,
         extra_hosts=opts.extra_hosts
     )


### PR DESCRIPTION
and use them in `make dev`

which is needed for OS X / etc. where host networking only sort-of exists

I needed this to test #257 because host networking doenn't work on Docker for Mac.