### PR TITLE
Fix cull_max option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Get Docker, then:
 docker pull jupyter/minimal-notebook
 export TOKEN=$( head -c 30 /dev/urandom | xxd -p )
 docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN --name=proxy jupyter/configurable-http-proxy --default-target http://127.0.0.1:9999
-docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN --name=tmpnb -v /var/run/docker.sock:/docker.sock jupyter/tmpnb python orchestrate.py --command='jupyter notebook --no-browser --port {port} --ip=0.0.0.0 --NotebookApp.base_url=/{base_path} --NotebookApp.port_retries=0 --NotebookApp.token="" --NotebookApp.disable_check_xsrf=True
+docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN --name=tmpnb -v /var/run/docker.sock:/docker.sock jupyter/tmpnb python orchestrate.py --command='jupyter notebook --no-browser --port {port} --ip=0.0.0.0 --NotebookApp.base_url=/{base_path} --NotebookApp.port_retries=0 --NotebookApp.token="" --NotebookApp.disable_check_xsrf=True'
 ```
 NOTE! This will disable Jupyter Notebook's token security. You can set `--NotebookApp.token` to a string if you want to add a minimal layer of security.
 
@@ -46,9 +46,10 @@ tmpnb_orchestrate:
     CONFIGPROXY_AUTH_TOKEN: 716238957362948752139417234
   volumes:
     - /var/run/docker.sock:/docker.sock
+  command: python orchestrate.py --command='jupyter notebook --no-browser --port {port} --ip=0.0.0.0 --NotebookApp.base_url=/{base_path} --NotebookApp.port_retries=0 --NotebookApp.token="" --NotebookApp.disable_check_xsrf=True'
 ```
 
-Then, you can launch the container with `docker-compose up`, no building is required since they pull directly form images.
+Then, you can launch the container with `docker-compose up`, no building is required since they pull directly from images.
 
 #### Advanced configuration
 

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -154,7 +154,7 @@ class SpawnHandler(BaseHandler):
                     redirect_path = path.lstrip('/')
 
                 url = "/{}/{}".format(container_path, redirect_path)
-            
+
             if container.token:
                 url = url_concat(url, {'token': container.token})
             app_log.info("Redirecting [%s] -> [%s].", self.request.path, url)
@@ -295,11 +295,11 @@ If host_network=True, the starting port assigned to notebook servers on the host
     tornado.options.define('cpu_quota', default=None, type=int,
         help=dedent("""
         Limit CPU quota, per container.
-        
+
         Units are CPU-µs per 100ms, so 1 CPU/container would be:
-        
+
             --cpu-quota=100000
-        
+
         """)
     )
     tornado.options.define('image', default="jupyter/minimal-notebook",
@@ -397,7 +397,7 @@ default docker bridge. Affects the semantics of container_port and container_ip.
     ]
 
     max_idle = datetime.timedelta(seconds=opts.cull_timeout)
-    max_age = datetime.timedelta(seconds=opts.cull_timeout)
+    max_age = datetime.timedelta(seconds=opts.cull_max)
     pool_name = opts.pool_name
     if pool_name is None:
         # Derive a valid container name from the image name by default.

--- a/spawnpool.py
+++ b/spawnpool.py
@@ -38,7 +38,7 @@ class PooledContainer(object):
         self.id = id
         self.path = path
         self.token = token
-    
+
     def __repr__(self):
         return 'PooledContainer(id=%s, path=%s)' % (self.id, self.path)
 
@@ -95,7 +95,7 @@ class SpawnPool():
 
         if not self.available:
             raise EmptyPoolError()
-        
+
         container = self.available.pop()
         # signal start on acquisition
         self.started[container.id] = datetime.utcnow()
@@ -159,7 +159,7 @@ class SpawnPool():
     def drain(self):
         '''
         Completely cleanout all available containers in the pool and immediately
-        schedule their replacement. Useful for refilling the pool with a new 
+        schedule their replacement. Useful for refilling the pool with a new
         container image while leaving in-use containers untouched. Returns the
         number of containers drained.
         '''
@@ -453,7 +453,7 @@ class Diagnosis():
                         last_activity = datetime.strptime(last_activity_s, _date_fmt)
                         started = self.started.get(container_id, None)
                         self.routes.add(result)
-                        if last_activity < idle_cutoff:
+                        if started and last_activity < idle_cutoff:
                             app_log.info("Culling %s, idle since %s", path, last_activity)
                             self.stale_routes.append(result)
                         elif started and started < started_cutoff:


### PR DESCRIPTION
I noticed that my containers were being culled at one hour, no matter what the cull_max option was set to, and tracked it down to the setting of `max_age` (not `opts.max_age` though). I also noticed that containers were being added to the `stale` list, even if they hadn't been started yet. I'm not sure if this is necessary, but I made it so containers would have to be started before they were added to the list. Finally, I fixed a few typos in README and I just noticed that my editor automatically removed some EOL whitespace. Please let me know if this is useful or not, particularly the `stale` change. Thanks for an awesome script!