### PR TITLE
Add the option for container user in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Get Docker, then:
 docker pull jupyter/minimal-notebook
 export TOKEN=$( head -c 30 /dev/urandom | xxd -p )
 docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN --name=proxy jupyter/configurable-http-proxy --default-target http://127.0.0.1:9999
-docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN --name=tmpnb -v /var/run/docker.sock:/docker.sock jupyter/tmpnb python orchestrate.py --command='jupyter notebook --no-browser --port {port} --ip=0.0.0.0 --NotebookApp.base_url=/{base_path} --NotebookApp.port_retries=0 --NotebookApp.token="" --NotebookApp.disable_check_xsrf=True'
+docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN --name=tmpnb -v /var/run/docker.sock:/docker.sock jupyter/tmpnb python orchestrate.py --container-user=jovyan --command='jupyter notebook --no-browser --port {port} --ip=0.0.0.0 --NotebookApp.base_url=/{base_path} --NotebookApp.port_retries=0 --NotebookApp.token="" --NotebookApp.disable_check_xsrf=True'
 ```
-NOTE! This will disable Jupyter Notebook's token security. You can set `--NotebookApp.token` to a string if you want to add a minimal layer of security.
+NOTE! This will disable Jupyter Notebook's token security. The option for `container-user` assures that the notebook will not run as a privileged user. You can set `--NotebookApp.token` to a string if you want to add a minimal layer of security.
 
 BAM! Visit your Docker host on port 8000 and you have a working tmpnb setup. The ` -v /var/run/docker.sock:/docker.sock` bit causes the orchestrator container to mount the docker client, which allows the orchestrator container to spawn docker containers on the host (see [this article](http://nathanleclaire.com/blog/2014/07/12/10-docker-tips-and-tricks-that-will-make-you-sing-a-whale-song-of-joy/#bind-mount-the-docker-socket-on-docker-run:1765430f0793020845eca6c8326a4e45) for more information).
 


### PR DESCRIPTION
I discovered the minergate-cli (cryptocurrency miner) running in one of my tmpnb containers (based on jupyter/docker-stacks datascience-notebook), fully eating all the 16 cores on server. With the recipe in "Quick start" session of README.md it is possible to install and run arbitrary software as root in the container. It is very dangerous, especially if running containers several days...
This can be cured by adding the option --container-user=jovyan to orchestrate.py in the sample command in section "Quick start" as suggested in issue #266.  That is the purpose of this PR.