### PR TITLE
Use docker v.2 instead of docker-py (v.1), first attempt

### DIFF
--- a/Dockerfile-alpine3.5
+++ b/Dockerfile-alpine3.5
@@ -1,8 +1,8 @@
 FROM alpine:3.5
 
 RUN apk update && apk add python3 py3-curl py3-tz py3-tornado \
-    && pip3 install docker-py==1.7.2 \
-    && pip3 install --upgrade pip \
+    && pip3 install --upgrade pip \    
+    && pip3 install docker \
     && rm -fr /root/.cache/pip && rm /var/cache/apk/* \
     && ln -s /usr/bin/python3 /usr/bin/python \
     && mkdir -p /srv/tmpnb 

--- a/Dockerfile-alpine3.6
+++ b/Dockerfile-alpine3.6
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN apk update && apk add python3 py3-curl py3-tz py3-tornado \
     && pip3 install --upgrade pip \    

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ orchestrate.py options:
                                    multiple directories can be specified by 
                                    using a comma-delimited string,
                                    directory path must provided in full
-                                   (eg: /home/steve/data/:/usr/data/:r), 
+                                   (eg: /home/steve/data/:/usr/data/:rw), 
                                    permissions default to rw
   --host-network                   Attaches the containers to the host
                                    networking instead of the default docker

--- a/README.md
+++ b/README.md
@@ -191,11 +191,13 @@ orchestrate.py options:
                                    comma-delimited string, specified in the
                                    form hostname:IP (default [])
   --host-directories               Mount the specified directory as a data
-                                   volume, multiple         directories can be
-                                   specified by using a comma-delimited string,
-                                   directory         path must provided in full
-                                   (eg: /home/steve/data/:r), permissions
-                                   default to         rw
+                                   volume at a user specified location 
+                                   (empty value to use the  default location), 
+                                   multiple directories can be specified by 
+                                   using a comma-delimited string,
+                                   directory path must provided in full
+                                   (eg: /home/steve/data/:/usr/data/:r), 
+                                   permissions default to rw
   --host-network                   Attaches the containers to the host
                                    networking instead of the default docker
                                    bridge. Affects the semantics of

--- a/dockworker.py
+++ b/dockworker.py
@@ -63,9 +63,9 @@ class DockerSpawner():
         # environment variable DOCKER_HOST takes precedence
         kwargs.setdefault('base_url', docker_host)
 
-        blocking_docker_client = docker.Client(version=version,
-                                               timeout=timeout,
-                                               **kwargs)
+        blocking_docker_client = docker.APIClient(version=version,
+                                                  timeout=timeout,
+                                                  **kwargs)
 
         executor = ThreadPoolExecutor(max_workers=max_workers)
 
@@ -153,8 +153,8 @@ class DockerSpawner():
             cpu_quota=container_config.cpu_quota,
         )
 
-        host_config = docker.Client.create_host_config(self.docker_client,
-                                                       **host_config)
+        host_config = docker.APIClient.create_host_config(self.docker_client,
+                                                          **host_config)
         
         cpu_shares = None
 

--- a/dockworker.py
+++ b/dockworker.py
@@ -131,13 +131,21 @@ class DockerSpawner():
             for index, item in enumerate(directories):
                 directory = item.split(":")[0]
                 try:
-                    permissions = item.split(":")[1]
+                    mount_path = item.split(":")[1]
+                    if not mount_path:  # /host/dir::ro
+                        raise IndexError
+                except IndexError:
+                    mount_path = '/mnt/vol' + str(index)
+                try:
+                    permissions = item.split(":")[2]
+                    if not permissions:
+                        raise IndexError
                 except IndexError:
                     permissions = 'rw'
+                volumes.append(mount_path)
 
-                volumes.append('/mnt/vol' + str(index))
                 volume_bindings[directory] = {
-                    'bind': '/mnt/vol' + str(index),
+                    'bind': mount_path,
                     'mode': permissions
                 }
 

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -354,10 +354,12 @@ default docker bridge. Affects the semantics of container_port and container_ip.
     )
     tornado.options.define('host_directories', default=None,
         help=dedent("""
-        Mount the specified directory as a data volume, multiple
+        Mount the specified directory as a data volume in a specified location
+        (provide an empty value to use a default mount path), multiple
         directories can be specified by using a comma-delimited string, directory
         path must provided in full (eg: /home/steve/data/:r), permissions default to
-        rw"""))
+        rw""")) 
+
     tornado.options.define('user_length', default=12,
         help="Length of the unique /user/:id path generated per container"
     )

--- a/orchestrate.py
+++ b/orchestrate.py
@@ -357,8 +357,8 @@ default docker bridge. Affects the semantics of container_port and container_ip.
         Mount the specified directory as a data volume in a specified location
         (provide an empty value to use a default mount path), multiple
         directories can be specified by using a comma-delimited string, directory
-        path must provided in full (eg: /home/steve/data/:r), permissions default to
-        rw""")) 
+        path must provided in full (eg: /home/steve/data/:/usr/data/:rw), permissions default to
+        rw"""))
 
     tornado.options.define('user_length', default=12,
         help="Length of the unique /user/:id path generated per container"


### PR DESCRIPTION
Really first attempt, based on changes from docker-py (v 1.x) to docker (v. 2.x) specified in issue #274. 
Seems to work, but I made this change without deep understanding of source code in `dockworker.py`. Now I am testing it on server with pool of 20 workers, each of us can see it on [jupymike server](http://jupymike.eu:8000).Will leave it running for at least 24 hours. 
