### PR TITLE
declare tmpnb deprecated, point to new resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ We recommend you switch to using JupyterHub.
 
 ### Configuration option 1:
 
-* JupyterHub with [tmpauthenticator](https://github.com/jupyterhub/tmpauthenticator)
+* [JupyterHub](https://jupyterhub.readthedocs.io/en/latest/) with [tmpauthenticator](https://github.com/jupyterhub/tmpauthenticator)
 
 ### Configuration option 2:
 
-* [BinderHub](https://github.com/jupyterhub/binderhub)
+* [BinderHub](https://binderhub.readthedocs.io/en/latest/)
 
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 Launches "temporary" Jupyter notebook servers.
 
+**WARNING: tmpnb is no longer actively maintained.**
+
+We recommend you switch to using JupyterHub.
+
+### Configuration option 1:
+
+* JupyterHub with [tmpauthenticator](https://github.com/jupyterhub/tmpauthenticator)
+
+### Configuration option 2:
+
+* [BinderHub](https://github.com/jupyterhub/binderhub)
+
+----------------
+
 ![tmpnb architecture](https://cloud.githubusercontent.com/assets/836375/5911140/c53e3978-a587-11e4-86a5-695469ef23a5.png)
 
 tmpnb launches a docker container for each user that requests one. In practice, this gets used to [provide temporary notebooks](https://tmpnb.org), demo the IPython notebook as part of [a Nature article](http://www.nature.com/news/interactive-notebooks-sharing-the-code-1.16261), or even [provide Jupyter kernels for publications](http://odewahn.github.io/publishing-workflows-for-jupyter/#1).


### PR DESCRIPTION
Since we're getting a flurry of new issues and I think we've all acknowledged JupyterHub + Binder as the ~~one true way~~ way to customize your own setup, I think it's time we declare it as such in the repo. Open to wordsmithing here.

/cc @willingc @yuvipanda @minrk 